### PR TITLE
FEAT: S3 연결

### DIFF
--- a/booklog/build.gradle
+++ b/booklog/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	implementation "org.apache.commons:commons-lang3:3.20.0"
 
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/booklog/src/main/java/com/example/booklog/aws/s3/AmazonS3Manager.java
+++ b/booklog/src/main/java/com/example/booklog/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,47 @@
+package com.example.booklog.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.booklog.global.common.Uuid;
+import com.example.booklog.global.common.repository.UuidRepository;
+import com.example.booklog.global.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    private final UuidRepository uuidRepository;
+
+    public String uploadFile(String keyName, MultipartFile file){
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        } catch (IOException e){
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public String generateReviewKeyName(Uuid uuid) {
+        return amazonConfig.getReviewPath() + '/' + uuid.getUuid();
+    }
+
+    public String generateProfileKeyName(Uuid uuid) {
+        return amazonConfig.getProfilePath() + '/' + uuid.getUuid();
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/common/Uuid.java
+++ b/booklog/src/main/java/com/example/booklog/global/common/Uuid.java
@@ -1,0 +1,19 @@
+package com.example.booklog.global.common;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Uuid extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uuid;
+}

--- a/booklog/src/main/java/com/example/booklog/global/common/repository/UuidRepository.java
+++ b/booklog/src/main/java/com/example/booklog/global/common/repository/UuidRepository.java
@@ -1,0 +1,7 @@
+package com.example.booklog.global.common.repository;
+
+import com.example.booklog.global.common.Uuid;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+}

--- a/booklog/src/main/java/com/example/booklog/global/config/AmazonConfig.java
+++ b/booklog/src/main/java/com/example/booklog/global/config/AmazonConfig.java
@@ -1,0 +1,58 @@
+package com.example.booklog.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+
+
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value(("${cloud.aws.s3.bucket"))
+    private String bucket;
+
+    @Value("${cloud.aws.s3.path.review}")
+    private String reviewPath;
+
+    @Value("${cloud.aws.s3.path.profile}") // 추가된 path 가져오기
+    private String profilePath;
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/config/web/MultipartJackson2HttpMessageConverter.java
+++ b/booklog/src/main/java/com/example/booklog/global/config/web/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package com.example.booklog.global.config.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /** "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기 */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/booklog/src/main/resources/application.yaml
+++ b/booklog/src/main/resources/application.yaml
@@ -31,3 +31,17 @@ kakao:
   book:
     rest-api-key: ${KAKAO_REST_API_KEY}
 
+cloud:
+  aws:
+    s3:
+      bucket: booklog-s3
+      path:
+        review : review
+        profile : profile
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACTION_ACCESS_KEY_ID}
+      secretKey: ${AWS_ACTION_SECRET_ACCESS_KEY}


### PR DESCRIPTION
AWS S3 연동
의존성 추가: 프로젝트에서 AWS S3 기능을 사용할 수 있도록 spring-cloud-starter-aws 의존성을 추가했습니다.

AmazonConfig 생성: AWS 자격 증명(Credentials) 및 S3 버킷 설정을 관리하며, AmazonS3와 AWSCredentialsProvider 빈(Bean)을 생성합니다.

AmazonS3Manager 구현: S3로의 파일 업로드를 처리하고, 리뷰 및 프로필용 S3 키 이름을 생성하는 기능을 담당합니다.

설정 업데이트: application.yaml 파일에 AWS S3 버킷 정보 및 자격 증명 설정을 추가했습니다.

UUID 관리
엔티티 및 레포지토리 추가: S3 파일 키의 고유 식별자를 관리하기 위해 Uuid 엔티티와 UuidRepository를 추가했습니다.

멀티파트(Multipart) 지원
메시지 컨버터 도입: multipart/form-data 콘텐츠 타입을 포함하는 HTTP 요청을 효율적으로 지원하기 위해 MultipartJackson2HttpMessageConverter를 도입했습니다.