### PR TITLE
[FEAT] 로그인 / 회원가입 API 구현

### DIFF
--- a/booklog/build.gradle
+++ b/booklog/build.gradle
@@ -55,6 +55,15 @@ dependencies {
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/booklog/src/main/java/com/example/booklog/domain/users/entity/AuthAccounts.java
+++ b/booklog/src/main/java/com/example/booklog/domain/users/entity/AuthAccounts.java
@@ -1,5 +1,6 @@
 package com.example.booklog.domain.users.entity;
 
+import com.example.booklog.global.auth.enums.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class AuthAccounts {
     @Column(name = "id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_auth_accounts_user"))
     private Users user;
 
@@ -34,6 +35,15 @@ public class AuthAccounts {
 
     @Column(name = "email", length = 255)
     private String email;
+
+    // ✅ 추가: LOCAL 로그인용 비밀번호
+    @Column(name = "password", length = 255)
+    private String password;
+
+    // ✅ 추가: 권한/역할 관리
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 20, nullable = false)
+    private Role role = Role.ROLE_USER;
 
     @Column(name = "display_name", length = 100)
     private String displayName;
@@ -49,13 +59,16 @@ public class AuthAccounts {
 
     @Builder
     public AuthAccounts(Users user, AuthProvider provider, String providerId,
-                        String email, String displayName, String profileImageUrl) {
+                        String email, String displayName, String profileImageUrl,
+                        String password, Role role) {
         this.user = user;
         this.provider = provider;
         this.providerId = providerId;
         this.email = email;
         this.displayName = displayName;
         this.profileImageUrl = profileImageUrl;
+        this.password = password;
+        this.role = role != null ? role : Role.ROLE_USER;
         this.connectedAt = LocalDateTime.now();
         this.lastLoginAt = LocalDateTime.now();
     }
@@ -68,6 +81,14 @@ public class AuthAccounts {
         this.email = email;
         this.displayName = displayName;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public void updateRole(Role role) {
+        this.role = role;
     }
 }
 

--- a/booklog/src/main/java/com/example/booklog/global/auth/Repository/AuthAccountsRepository.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/Repository/AuthAccountsRepository.java
@@ -1,0 +1,24 @@
+package com.example.booklog.global.auth.Repository;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import com.example.booklog.domain.users.entity.AuthProvider;
+import com.example.booklog.domain.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AuthAccountsRepository extends JpaRepository<AuthAccounts, Long> {
+
+    // 이메일과 provider로 조회 (로그인용)
+    Optional<AuthAccounts> findByEmailAndProvider(String email, AuthProvider provider);
+
+    // 이메일로 조회 (중복 체크용)
+    Optional<AuthAccounts> findByEmail(String email);
+
+    // user로 모든 인증 수단 조회
+    List<AuthAccounts> findByUser(Users user);
+
+    // provider_id와 provider로 조회 (OAuth용)
+    Optional<AuthAccounts> findByProviderIdAndProvider(String providerId, AuthProvider provider);
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/controller/AuthController.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.example.booklog.global.auth.controller;
+
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+import com.example.booklog.global.auth.exception.AuthSuccessCode;
+import com.example.booklog.global.auth.service.AuthCommandService;
+import com.example.booklog.global.auth.service.AuthQueryService;
+import com.example.booklog.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthCommandService authCommandService;
+    private final AuthQueryService authQueryService;
+
+    // 회원가입
+    @PostMapping("/sign-up")
+    public ApiResponse<AuthResDTO.JoinDTO> signUp(
+            @RequestBody @Valid AuthReqDTO.JoinDTO dto
+    ){
+        return ApiResponse.onSuccess(
+                AuthSuccessCode.SIGNUP_SUCCESS,
+                authCommandService.signup(dto)
+        );
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ApiResponse<AuthResDTO.LoginDTO> login(
+            @RequestBody @Valid AuthReqDTO.LoginDTO dto
+    ){
+        return ApiResponse.onSuccess(
+                AuthSuccessCode.LOGIN_SUCCESS,
+                authQueryService.login(dto)
+        );
+    }
+
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/converter/AuthConverter.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/converter/AuthConverter.java
@@ -1,0 +1,52 @@
+package com.example.booklog.global.auth.converter;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import com.example.booklog.domain.users.entity.AuthProvider;
+import com.example.booklog.domain.users.entity.UserStatus;
+import com.example.booklog.domain.users.entity.Users;
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+import com.example.booklog.global.auth.enums.Role;
+
+public class AuthConverter {
+
+    // DTO, Encrypted Password, Role -> AuthAccounts + Users
+    public static AuthAccounts toAuthAccount(
+            AuthReqDTO.JoinDTO dto,
+            String encryptedPassword,
+            Role role
+    ) {
+        // Users 생성
+        Users user = Users.builder()
+                .nickname(dto.name())
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        // AuthAccounts 생성 (LOCAL provider)
+        return AuthAccounts.builder()
+                .user(user)
+                .provider(AuthProvider.LOCAL)
+                .providerId(dto.email())  // LOCAL은 email을 providerId로 사용
+                .email(dto.email())
+                .displayName(dto.name())
+                .password(encryptedPassword)
+                .role(role)
+                .build();
+    }
+
+    // AuthAccounts, AccessToken -> LoginDTO
+    public static AuthResDTO.LoginDTO toLoginDTO(AuthAccounts account, String accessToken) {
+        return AuthResDTO.LoginDTO.builder()
+                .userId(account.getUser().getId())
+                .accessToken(accessToken)
+                .build();
+    }
+
+    // AuthAccounts -> JoinDTO
+    public static AuthResDTO.JoinDTO toJoinDTO(AuthAccounts account) {
+        return AuthResDTO.JoinDTO.builder()
+                .userId(account.getUser().getId())
+                .email(account.getEmail())
+                .build();
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/dto/AuthReqDTO.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/dto/AuthReqDTO.java
@@ -1,0 +1,24 @@
+package com.example.booklog.global.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AuthReqDTO {
+
+    // 로그인
+    public record LoginDTO(
+            @NotBlank
+            String email,
+            @NotBlank
+            String password
+    ) {}
+
+    // 회원가입
+    public record JoinDTO(
+            @NotBlank
+            String name,
+            @NotBlank
+            String email,
+            @NotBlank
+            String password
+    ) {}
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/dto/AuthResDTO.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/dto/AuthResDTO.java
@@ -1,0 +1,21 @@
+package com.example.booklog.global.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public class AuthResDTO {
+
+    // 회원가입
+    @Builder
+    public record JoinDTO(
+            Long userId,
+            String email
+    ){}
+
+    // 로그인
+    @Builder
+    public record LoginDTO(
+            Long userId,
+            String accessToken
+    ){}
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/enums/Role.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/enums/Role.java
@@ -1,0 +1,5 @@
+package com.example.booklog.global.auth.enums;
+
+public enum Role {
+    ROLE_ADMIN, ROLE_USER
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthErrorCode.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.booklog.global.auth.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode {
+    // 인증 관련 에러
+    NOT_FOUND("AUTH_001", "사용자를 찾을 수 없습니다."),
+    INVALID("AUTH_002", "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED("AUTH_003", "인증되지 않은 사용자입니다."),
+    FORBIDDEN("AUTH_004", "권한이 없습니다."),
+    TOKEN_EXPIRED("AUTH_005", "토큰이 만료되었습니다."),
+    INVALID_TOKEN("AUTH_006", "유효하지 않은 토큰입니다."),
+    DUPLICATE_EMAIL("AUTH_007", "이미 존재하는 이메일입니다."),
+    INVALID_EMAIL_FORMAT("AUTH_008", "올바르지 않은 이메일 형식입니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthException.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.example.booklog.global.auth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public AuthException(AuthErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthSuccessCode.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/exception/AuthSuccessCode.java
@@ -1,0 +1,17 @@
+package com.example.booklog.global.auth.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode {
+    // 인증 관련 성공 코드
+    SIGNUP_SUCCESS("AUTH_S001", "회원가입이 완료되었습니다."),
+    LOGIN_SUCCESS("AUTH_S002", "로그인에 성공했습니다."),
+    LOGOUT_SUCCESS("AUTH_S003", "로그아웃되었습니다."),
+    TOKEN_REFRESH_SUCCESS("AUTH_S004", "토큰이 갱신되었습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/security/AuthenticationEntryPointImpl.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/security/AuthenticationEntryPointImpl.java
@@ -1,0 +1,35 @@
+package com.example.booklog.global.auth.security;
+
+import com.example.booklog.global.common.ApiResponse;
+import com.example.booklog.global.common.GeneralErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(
+                GeneralErrorCode.UNAUTHORIZED,
+                null
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/security/CustomUserDetails.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/security/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.example.booklog.global.auth.security;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final AuthAccounts account;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(account.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return account.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return account.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Long getUserId() {
+        return account.getUser().getId();
+    }
+
+    public AuthAccounts getAccount() {
+        return account;
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/security/CustomUserDetailsService.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.booklog.global.auth.security;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import com.example.booklog.domain.users.entity.AuthProvider;
+import com.example.booklog.global.auth.Repository.AuthAccountsRepository;
+import com.example.booklog.global.auth.exception.AuthErrorCode;
+import com.example.booklog.global.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AuthAccountsRepository authAccountsRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // username(이메일)으로 LOCAL provider의 AuthAccounts 조회
+        AuthAccounts account = authAccountsRepository
+                .findByEmailAndProvider(username, AuthProvider.LOCAL)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND));
+
+        // CustomUserDetails 반환
+        return new CustomUserDetails(account);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/security/JwtAuthFilter.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/security/JwtAuthFilter.java
@@ -1,0 +1,71 @@
+package com.example.booklog.global.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            // 토큰 가져오기
+            String token = request.getHeader("Authorization");
+            // token이 없거나 Bearer가 아니면 넘기기
+            if (token == null || !token.startsWith("Bearer ")) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            // Bearer이면 추출
+            token = token.replace("Bearer ", "");
+            // AccessToken 검증하기: 올바른 토큰이면
+            if (jwtUtil.isValid(token)) {
+                // 토큰에서 이메일 추출
+                String email = jwtUtil.getEmail(token);
+                // 인증 객체 생성: 이메일로 찾아온 뒤, 인증 객체 생성
+                UserDetails user = customUserDetailsService.loadUserByUsername(email);
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        user,
+                        null,
+                        user.getAuthorities()
+                );
+                // 인증 완료 후 SecurityContextHolder에 넣기
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("code", "UNAUTHORIZED");
+            errorResponse.put("message", "인증에 실패했습니다: " + e.getMessage());
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writeValue(response.getOutputStream(), errorResponse);
+        }
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/security/JwtUtil.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/security/JwtUtil.java
@@ -1,0 +1,92 @@
+package com.example.booklog.global.auth.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Duration accessExpiration;
+
+    public JwtUtil(
+            @Value("${jwt.token.secretKey}") String secret,
+            @Value("${jwt.token.expiration.access}") Long accessExpiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpiration = Duration.ofMillis(accessExpiration);
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(CustomUserDetails user) {
+        return createToken(user, accessExpiration);
+    }
+
+    /** 토큰에서 이메일 가져오기
+     *
+     * @param token 유저 정보를 추출할 토큰
+     * @return 유저 이메일을 토큰에서 추출합니다
+     */
+    public String getEmail(String token) {
+        try {
+            return getClaims(token).getPayload().getSubject(); // Parsing해서 Subject 가져오기
+        } catch (JwtException e) {
+            return null;
+        }
+    }
+
+    /** 토큰 유효성 확인
+     *
+     * @param token 유효한지 확인할 토큰
+     * @return True, False 반환합니다
+     */
+    public boolean isValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    // 토큰 생성
+    private String createToken(CustomUserDetails user, Duration expiration) {
+        Instant now = Instant.now();
+
+        // 인가 정보
+        String authorities = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .subject(user.getUsername()) // User 이메일을 Subject로
+                .claim("role", authorities)
+                .claim("email", user.getUsername())
+                .issuedAt(Date.from(now)) // 언제 발급한지
+                .expiration(Date.from(now.plus(expiration))) // 언제까지 유효한지
+                .signWith(secretKey) // sign할 Key
+                .compact();
+    }
+
+    // 토큰 정보 가져오기
+    private Jws<Claims> getClaims(String token) throws JwtException {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .clockSkewSeconds(60)
+                .build()
+                .parseSignedClaims(token);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/service/AuthCommandService.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/service/AuthCommandService.java
@@ -1,0 +1,9 @@
+package com.example.booklog.global.auth.service;
+
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+
+public interface AuthCommandService {
+
+    AuthResDTO.JoinDTO signup(AuthReqDTO.JoinDTO dto);
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/service/AuthCommandServiceImpl.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/service/AuthCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package com.example.booklog.global.auth.service;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import com.example.booklog.domain.users.entity.AuthProvider;
+import com.example.booklog.global.auth.Repository.AuthAccountsRepository;
+import com.example.booklog.global.auth.converter.AuthConverter;
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+import com.example.booklog.global.auth.enums.Role;
+import com.example.booklog.global.auth.exception.AuthErrorCode;
+import com.example.booklog.global.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final AuthAccountsRepository authAccountsRepository;
+
+    // 회원가입
+    @Override
+    @Transactional
+    public AuthResDTO.JoinDTO signup(AuthReqDTO.JoinDTO dto) {
+        // 1. 이메일 중복 체크 (LOCAL provider)
+        if (authAccountsRepository.findByEmailAndProvider(dto.email(), AuthProvider.LOCAL).isPresent()) {
+            throw new AuthException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 2. 비밀번호 암호화
+        String encryptedPassword = passwordEncoder.encode(dto.password());
+
+        // 3. AuthAccounts + Users 생성
+        AuthAccounts account = AuthConverter.toAuthAccount(dto, encryptedPassword, Role.ROLE_USER);
+
+        // 4. DB 저장 (cascade로 Users도 함께 저장됨)
+        AuthAccounts savedAccount = authAccountsRepository.save(account);
+
+        // 5. 응답 DTO 반환
+        return AuthConverter.toJoinDTO(savedAccount);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/service/AuthQueryService.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/service/AuthQueryService.java
@@ -1,0 +1,10 @@
+package com.example.booklog.global.auth.service;
+
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+import jakarta.validation.Valid;
+
+public interface AuthQueryService {
+
+    AuthResDTO.LoginDTO login(AuthReqDTO.@Valid LoginDTO dto);
+}

--- a/booklog/src/main/java/com/example/booklog/global/auth/service/AuthQueryServiceImpl.java
+++ b/booklog/src/main/java/com/example/booklog/global/auth/service/AuthQueryServiceImpl.java
@@ -1,0 +1,52 @@
+package com.example.booklog.global.auth.service;
+
+import com.example.booklog.domain.users.entity.AuthAccounts;
+import com.example.booklog.domain.users.entity.AuthProvider;
+import com.example.booklog.global.auth.Repository.AuthAccountsRepository;
+import com.example.booklog.global.auth.converter.AuthConverter;
+import com.example.booklog.global.auth.dto.AuthReqDTO;
+import com.example.booklog.global.auth.dto.AuthResDTO;
+import com.example.booklog.global.auth.exception.AuthErrorCode;
+import com.example.booklog.global.auth.exception.AuthException;
+import com.example.booklog.global.auth.security.CustomUserDetails;
+import com.example.booklog.global.auth.security.JwtUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthQueryServiceImpl implements AuthQueryService {
+
+    private final AuthAccountsRepository authAccountsRepository;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder encoder;
+
+    @Override
+    @Transactional
+    public AuthResDTO.LoginDTO login(AuthReqDTO.@Valid LoginDTO dto) {
+        // 1. LOCAL provider로 AuthAccounts 조회
+        AuthAccounts account = authAccountsRepository
+                .findByEmailAndProvider(dto.email(), AuthProvider.LOCAL)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND));
+
+        // 2. 비밀번호 검증
+        if (!encoder.matches(dto.password(), account.getPassword())) {
+            throw new AuthException(AuthErrorCode.INVALID);
+        }
+
+        // 3. 마지막 로그인 시간 업데이트
+        account.updateLastLogin();
+
+        // 4. CustomUserDetails 생성
+        CustomUserDetails userDetails = new CustomUserDetails(account);
+
+        // 5. JWT 액세스 토큰 발급
+        String accessToken = jwtUtil.createAccessToken(userDetails);
+
+        // 6. 응답 DTO 반환
+        return AuthConverter.toLoginDTO(account, accessToken);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/common/ApiResponse.java
+++ b/booklog/src/main/java/com/example/booklog/global/common/ApiResponse.java
@@ -1,0 +1,52 @@
+package com.example.booklog.global.common;
+
+import com.example.booklog.global.auth.exception.AuthErrorCode;
+import com.example.booklog.global.auth.exception.AuthSuccessCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success, String code, String message, T data) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 성공 응답 (AuthSuccessCode 사용)
+    public static <T> ApiResponse<T> onSuccess(AuthSuccessCode successCode, T data) {
+        return new ApiResponse<>(true, successCode.getCode(), successCode.getMessage(), data);
+    }
+
+    // 성공 응답 (데이터 없이)
+    public static <T> ApiResponse<T> onSuccess(AuthSuccessCode successCode) {
+        return new ApiResponse<>(true, successCode.getCode(), successCode.getMessage(), null);
+    }
+
+    // 실패 응답 (AuthErrorCode 사용)
+    public static <T> ApiResponse<T> onFailure(AuthErrorCode errorCode, T data) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), data);
+    }
+
+    // 실패 응답 (데이터 없이)
+    public static <T> ApiResponse<T> onFailure(AuthErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    // 실패 응답 (GeneralErrorCode 사용)
+    public static <T> ApiResponse<T> onFailure(GeneralErrorCode errorCode, T data) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), data);
+    }
+
+    // 실패 응답 (GeneralErrorCode 사용, 데이터 없이)
+    public static <T> ApiResponse<T> onFailure(GeneralErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/common/GeneralErrorCode.java
+++ b/booklog/src/main/java/com/example/booklog/global/common/GeneralErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.booklog.global.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralErrorCode {
+    // 일반 에러 코드
+    BAD_REQUEST("G001", "잘못된 요청입니다."),
+    UNAUTHORIZED("G002", "인증되지 않은 사용자입니다."),
+    FORBIDDEN("G003", "권한이 없습니다."),
+    NOT_FOUND("G004", "리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR("G005", "서버 내부 오류가 발생했습니다."),
+    METHOD_NOT_ALLOWED("G006", "허용되지 않은 메서드입니다."),
+    VALIDATION_ERROR("G007", "입력값 검증에 실패했습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/booklog/src/main/java/com/example/booklog/global/common/GlobalExceptionHandler.java
+++ b/booklog/src/main/java/com/example/booklog/global/common/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.example.booklog.global.common;
+
+import com.example.booklog.global.auth.exception.AuthErrorCode;
+import com.example.booklog.global.auth.exception.AuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * AuthException 처리
+     */
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthException(AuthException e) {
+        log.error("AuthException: {}", e.getMessage(), e);
+        AuthErrorCode errorCode = e.getErrorCode();
+
+        ApiResponse<Void> response = ApiResponse.onFailure(errorCode);
+
+        // HTTP 상태 코드 매핑
+        HttpStatus status = mapAuthErrorToHttpStatus(errorCode);
+
+        return ResponseEntity.status(status).body(response);
+    }
+
+    /**
+     * Validation 예외 처리 (@Valid 검증 실패)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(
+            MethodArgumentNotValidException e) {
+        log.error("Validation Exception: {}", e.getMessage());
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        ApiResponse<Map<String, String>> response = ApiResponse.onFailure(
+                GeneralErrorCode.VALIDATION_ERROR,
+                errors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    /**
+     * 기타 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleGeneralException(Exception e) {
+        log.error("Unexpected Exception: {}", e.getMessage(), e);
+
+        ApiResponse<String> response = ApiResponse.onFailure(
+                GeneralErrorCode.INTERNAL_SERVER_ERROR,
+                e.getMessage()
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    /**
+     * AuthErrorCode를 HTTP Status로 매핑
+     */
+    private HttpStatus mapAuthErrorToHttpStatus(AuthErrorCode errorCode) {
+        return switch (errorCode) {
+            case NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case UNAUTHORIZED, TOKEN_EXPIRED, INVALID_TOKEN -> HttpStatus.UNAUTHORIZED;
+            case FORBIDDEN -> HttpStatus.FORBIDDEN;
+            case DUPLICATE_EMAIL, INVALID_EMAIL_FORMAT, INVALID -> HttpStatus.BAD_REQUEST;
+        };
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/config/SecurityConfig.java
+++ b/booklog/src/main/java/com/example/booklog/global/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package com.example.booklog.global.config;
+
+import com.example.booklog.global.auth.security.AuthenticationEntryPointImpl;
+import com.example.booklog.global.auth.security.CustomUserDetailsService;
+import com.example.booklog.global.auth.security.JwtAuthFilter;
+import com.example.booklog.global.auth.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private final String[] allowUris = {
+            "/sign-up",
+            "/login",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers(allowUris).permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                // 폼로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                // 세션 관리 - JWT 기반이므로 STATELESS로 설정
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(jwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .csrf(AbstractHttpConfigurer::disable)
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                ).exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint()))
+        ;
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthFilter jwtAuthFilter() {
+        return new JwtAuthFilter(jwtUtil, customUserDetailsService);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new AuthenticationEntryPointImpl();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/global/config/SwaggerConfig.java
+++ b/booklog/src/main/java/com/example/booklog/global/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.example.booklog.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securitySchemeName = "bearerAuth";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securitySchemeName);
+        Components components = new Components().addSecuritySchemes(securitySchemeName,
+                new SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .info(new Info().title("BookLog API 명세서").version("v1"))
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/booklog/src/main/resources/application.yaml
+++ b/booklog/src/main/resources/application.yaml
@@ -46,3 +46,9 @@ cloud:
     credentials:
       accessKey: ${AWS_ACTION_ACCESS_KEY_ID}
       secretKey: ${AWS_ACTION_SECRET_ACCESS_KEY}
+
+jwt:
+  token:
+    secretKey: ${JWT_SECRET_KEY}
+    expiration:
+      access: 7200000


### PR DESCRIPTION
🔐 인증 및 보안 인프라
의존성 추가: build.gradle에 Spring Security 및 JWT 관련 라이브러리를 추가하여 토큰 기반 보안의 기반을 마련했습니다.

보안 컴포넌트 구현: JWT 인증 필터(JwtAuthFilter), 커스텀 유저 상세 정보(CustomUserDetails, CustomUserDetailsService), 그리고 인증되지 않은 접근을 처리하기 위한 인증 진입점(AuthenticationEntryPoint)을 구현했습니다.

🏗️ 도메인 및 데이터 계층 강화
엔티티 수정: AuthAccounts 엔티티가 비밀번호 저장 및 역할 관리를 지원하도록 업데이트되었으며, 비밀번호와 역할을 수정하는 메서드가 추가되었습니다.

레포지토리 생성: 이메일, 제공자(Provider), 사용자 또는 제공자 ID를 통해 인증 계정을 조회할 수 있는 AuthAccountsRepository를 도입했습니다.

역할 정의: 사용자 권한 관리를 위한 Role 열거형(Admin, User)을 추가했습니다.

🌐 API 계층 (DTO, 컨트롤러, 컨버터)
데이터 전송 객체(DTO): 로그인 및 회원가입 요청과 응답을 위한 DTO들을 추가했습니다.

컨트롤러 구현: 회원가입 및 로그인 엔드포인트를 가진 AuthController를 구현했으며, 비즈니스 로직은 Command 및 Query 서비스로 위임했습니다.

변환 유틸리티: DTO와 엔티티 간의 변환을 담당하는 AuthConverter를 추가했습니다.

⚠️ 인증 예외 처리
에러 코드 정의: 인증 관련 에러 및 성공 코드를 관리하는 열거형과 클래스를 정의했습니다.

커스텀 예외: 일관된 에러 처리를 위해 AuthException 클래스를 도입했습니다.