### PR TITLE
feat: 사용자 도서 추천 기능(홈)

### DIFF
--- a/booklog/src/main/java/com/example/booklog/domain/ai/entity/GptRecommendationRequest.java
+++ b/booklog/src/main/java/com/example/booklog/domain/ai/entity/GptRecommendationRequest.java
@@ -1,0 +1,38 @@
+package com.example.booklog.domain.ai.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * GPT 추천 요청 DTO
+ * - 온보딩 필드 + 최근 검색어를 기반으로 작가/장르 추론
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GptRecommendationRequest {
+
+    /**
+     * 추천 근거 필드명 (예: preferredMood1)
+     */
+    private String fieldName;
+
+    /**
+     * 추천 근거 값 (예: CALM)
+     */
+    private String fieldValue;
+
+    /**
+     * 필드 설명 (예: 잔잔한)
+     */
+    private String fieldDescription;
+
+    /**
+     * 사용자 최근 검색어 목록
+     */
+    private String recentSearchKeywords;
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/ai/entity/GptRecommendationResponse.java
+++ b/booklog/src/main/java/com/example/booklog/domain/ai/entity/GptRecommendationResponse.java
@@ -1,0 +1,36 @@
+package com.example.booklog.domain.ai.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * GPT 추천 응답 DTO
+ * - 검색 키워드 생성용
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GptRecommendationResponse {
+
+    /**
+     * 추천 작가 타입 또는 작가명
+     * 예: "박민규 같은 작가", "실험적인 작가"
+     */
+    private String authorType;
+
+    /**
+     * 추천 장르
+     * 예: "현대문학", "SF"
+     */
+    private String genre;
+
+    /**
+     * GPT가 생성한 검색 키워드
+     * 예: "실험적 현대문학"
+     */
+    private String searchKeyword;
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/ai/service/GptService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/ai/service/GptService.java
@@ -1,0 +1,297 @@
+package com.example.booklog.domain.ai.service;
+
+import com.example.booklog.domain.ai.entity.GptRecommendationRequest;
+import com.example.booklog.domain.ai.entity.GptRecommendationResponse;
+import com.example.booklog.global.config.GptConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GPT 서비스 - OpenAI API 호출
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GptService {
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    private final GptConfig gptConfig;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 온보딩 기반 도서 추천 키워드 생성
+     * - GPT에게 작가 타입과 장르를 추론하도록 요청
+     * - 응답에서 검색 키워드를 추출
+     *
+     * @param request GPT 추천 요청
+     * @return 검색 키워드 정보
+     */
+    public GptRecommendationResponse generateRecommendationKeyword(GptRecommendationRequest request) {
+        try {
+            log.info("GPT 추천 키워드 생성 시작 - field: {}, value: {}",
+                    request.getFieldName(), request.getFieldValue());
+
+            // 프롬프트 생성
+            String prompt = buildRecommendationPrompt(request);
+
+            // GPT API 호출
+            String gptResponse = callGptApi(prompt);
+
+            // 응답 파싱
+            GptRecommendationResponse response = parseGptResponse(gptResponse);
+
+            log.info("GPT 추천 키워드 생성 완료 - keyword: {}", response.getSearchKeyword());
+            return response;
+
+        } catch (Exception e) {
+            log.error("GPT 추천 키워드 생성 실패 - field: {}, error: {}",
+                    request.getFieldName(), e.getMessage(), e);
+
+            // 실패 시 기본 검색어 반환 (빈 결과 방지)
+            return GptRecommendationResponse.builder()
+                    .authorType("추천 작가")
+                    .genre(request.getFieldDescription())
+                    .searchKeyword(request.getFieldDescription() + " 소설")
+                    .build();
+        }
+    }
+
+    /**
+     * 도서 정보 기반 분위기/문체/몰입도 키워드 분석
+     * - 서재 기반 및 인기 도서 추천에서 사용
+     *
+     * @param bookTitle 도서 제목
+     * @param author 작가명
+     * @param publisher 출판사
+     * @return 분위기, 문체, 몰입도 키워드 (각 1개씩)
+     */
+    public Map<String, String> analyzeBookKeywords(String bookTitle, String author, String publisher) {
+        try {
+            log.info("GPT 도서 키워드 분석 시작 - title: {}, author: {}", bookTitle, author);
+
+            // 프롬프트 생성
+            String prompt = buildBookAnalysisPrompt(bookTitle, author, publisher);
+
+            // GPT API 호출
+            String gptResponse = callGptApi(prompt);
+
+            // 응답 파싱
+            Map<String, String> keywords = parseBookKeywordsResponse(gptResponse);
+
+            log.info("GPT 도서 키워드 분석 완료 - mood: {}, style: {}, immersion: {}",
+                    keywords.get("mood"), keywords.get("style"), keywords.get("immersion"));
+            return keywords;
+
+        } catch (Exception e) {
+            log.error("GPT 도서 키워드 분석 실패 - title: {}, error: {}", bookTitle, e.getMessage(), e);
+
+            // 실패 시 기본 키워드 반환
+            Map<String, String> defaultKeywords = new HashMap<>();
+            defaultKeywords.put("mood", "잔잔한");
+            defaultKeywords.put("style", "간결한");
+            defaultKeywords.put("immersion", "편안한");
+            return defaultKeywords;
+        }
+    }
+
+    /**
+     * GPT API 호출
+     */
+    private String callGptApi(String prompt) {
+        try {
+            // API 키 유효성 검사
+            String apiKey = gptConfig.getSecretKey();
+            if (apiKey == null || apiKey.isEmpty() || apiKey.equals("dummy-key-for-development")) {
+                log.warn("GPT API 키가 설정되지 않음. 기본 응답 반환");
+                throw new RuntimeException("GPT API 키 미설정");
+            }
+
+            // HTTP 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            // 요청 바디 생성
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("model", gptConfig.getModel());
+            requestBody.put("messages", List.of(
+                    Map.of("role", "system", "content", "당신은 도서 추천 전문가입니다. 사용자의 취향을 분석하여 적합한 작가와 장르를 추천합니다."),
+                    Map.of("role", "user", "content", prompt)
+            ));
+            requestBody.put("temperature", 0.7);
+            requestBody.put("max_tokens", 300);
+
+            // API 요청
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    OPENAI_API_URL,
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return extractContentFromResponse(response.getBody());
+            } else {
+                throw new RuntimeException("GPT API 호출 실패: " + response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            log.error("GPT API 호출 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("GPT API 호출 실패", e);
+        }
+    }
+
+    /**
+     * GPT API 응답에서 content 추출
+     */
+    private String extractContentFromResponse(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode choices = root.path("choices");
+            if (choices.isArray() && !choices.isEmpty()) {
+                return choices.get(0).path("message").path("content").asText();
+            }
+            throw new RuntimeException("GPT 응답 형식 오류");
+        } catch (Exception e) {
+            log.error("GPT 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("GPT 응답 파싱 실패", e);
+        }
+    }
+
+    /**
+     * 추천을 위한 프롬프트 생성
+     */
+    private String buildRecommendationPrompt(GptRecommendationRequest request) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("사용자의 독서 취향 정보:\n");
+        prompt.append("- ").append(request.getFieldName()).append(": ")
+              .append(request.getFieldValue()).append(" (")
+              .append(request.getFieldDescription()).append(")\n");
+
+        if (request.getRecentSearchKeywords() != null && !request.getRecentSearchKeywords().isEmpty()) {
+            prompt.append("- 최근 검색어: ").append(request.getRecentSearchKeywords()).append("\n");
+        }
+
+        prompt.append("\n위 정보를 바탕으로 사용자가 좋아할 만한 도서를 찾기 위한 정보를 제공해주세요.\n");
+        prompt.append("다음 형식으로 응답해주세요:\n");
+        prompt.append("작가타입: [작가명 또는 특징 1~2단어]\n");
+        prompt.append("장르: [장르명 1~2단어]\n");
+        prompt.append("검색키워드: [도서 검색용 키워드 2~3단어]\n");
+        prompt.append("\n※ 중요: 각 항목은 반드시 짧은 단어로만 응답하세요. 문장이 아닌 핵심 키워드만 작성하세요.");
+
+        return prompt.toString();
+    }
+
+    /**
+     * 도서 분석용 프롬프트 생성
+     */
+    private String buildBookAnalysisPrompt(String bookTitle, String author, String publisher) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("다음 도서 정보를 분석하여 분위기, 문체, 몰입도 키워드를 추천해주세요.\n\n");
+        prompt.append("도서 정보:\n");
+        prompt.append("- 제목: ").append(bookTitle).append("\n");
+        prompt.append("- 작가: ").append(author).append("\n");
+        if (publisher != null && !publisher.isEmpty()) {
+            prompt.append("- 출판사: ").append(publisher).append("\n");
+        }
+
+        prompt.append("\n다음 형식으로 응답해주세요:\n");
+        prompt.append("분위기: [따뜻한, 잔잔한, 서늘한, 몽환적인, 유쾌한, 어두운 중 1개]\n");
+        prompt.append("문체: [간결한, 화려한, 담백한, 섬세한, 직설적, 은유적 중 1개]\n");
+        prompt.append("몰입도: [빠른전개, 느린전개, 긴장감있는, 편안한, 현실적, 환상적, 논리적, 감성적 중 1개]\n");
+        prompt.append("\n※ 중요: 각 항목은 반드시 위에서 제시한 키워드 중 1개만 선택하세요. 다른 단어는 사용하지 마세요.");
+
+        return prompt.toString();
+    }
+
+    /**
+     * 도서 키워드 분석 응답 파싱
+     */
+    private Map<String, String> parseBookKeywordsResponse(String gptContent) {
+        Map<String, String> keywords = new HashMap<>();
+
+        try {
+            String[] lines = gptContent.split("\n");
+
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("분위기:")) {
+                    keywords.put("mood", trimmed.substring(trimmed.indexOf(":") + 1).trim());
+                } else if (trimmed.startsWith("문체:")) {
+                    keywords.put("style", trimmed.substring(trimmed.indexOf(":") + 1).trim());
+                } else if (trimmed.startsWith("몰입도:")) {
+                    keywords.put("immersion", trimmed.substring(trimmed.indexOf(":") + 1).trim());
+                }
+            }
+
+            // 기본값 설정 (파싱 실패 시)
+            keywords.putIfAbsent("mood", "잔잔한");
+            keywords.putIfAbsent("style", "간결한");
+            keywords.putIfAbsent("immersion", "편안한");
+
+            return keywords;
+
+        } catch (Exception e) {
+            log.error("도서 키워드 응답 파싱 실패: {}", e.getMessage(), e);
+            keywords.put("mood", "잔잔한");
+            keywords.put("style", "간결한");
+            keywords.put("immersion", "편안한");
+            return keywords;
+        }
+    }
+
+    /**
+     * GPT 응답 파싱
+     * 응답 형식:
+     * 작가타입: xxx
+     * 장르: xxx
+     * 검색키워드: xxx
+     */
+    private GptRecommendationResponse parseGptResponse(String gptContent) {
+        try {
+            String[] lines = gptContent.split("\n");
+            String authorType = "";
+            String genre = "";
+            String searchKeyword = "";
+
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("작가타입:") || trimmed.startsWith("작가 타입:")) {
+                    authorType = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+                } else if (trimmed.startsWith("장르:")) {
+                    genre = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+                } else if (trimmed.startsWith("검색키워드:") || trimmed.startsWith("검색 키워드:")) {
+                    searchKeyword = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+                }
+            }
+
+            // 검색키워드가 비어있으면 작가타입 + 장르 조합
+            if (searchKeyword.isEmpty()) {
+                searchKeyword = genre + " " + authorType;
+            }
+
+            return GptRecommendationResponse.builder()
+                    .authorType(authorType)
+                    .genre(genre)
+                    .searchKeyword(searchKeyword)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("GPT 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("GPT 응답 파싱 실패", e);
+        }
+    }
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/BookRecommendationCardResponse.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/BookRecommendationCardResponse.java
@@ -1,0 +1,65 @@
+package com.example.booklog.domain.onboarding.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 도서 추천 카드 응답 DTO
+ * - 온보딩 기반 개인화 추천 카드
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookRecommendationCardResponse {
+
+    /**
+     * 도서 제목
+     */
+    private String bookTitle;
+
+    /**
+     * 저자
+     */
+    private String author;
+
+    /**
+     * 출판사
+     */
+    private String publisher;
+
+    /**
+     * 썸네일 URL
+     */
+    private String thumbnailUrl;
+
+    /**
+     * 추천 근거 필드명
+     * 예: "preferredMood1", "sentenceBreath"
+     */
+    private String recommendationSourceField;
+
+    /**
+     * 추천 근거 값
+     * 예: "CALM", "CONCISE"
+     */
+    private String recommendationSourceValue;
+
+    /**
+     * 분위기 키워드
+     */
+    private String moodKeyword;
+
+    /**
+     * 문체 키워드
+     */
+    private String styleKeyword;
+
+    /**
+     * 몰입도 키워드
+     */
+    private String immersionKeyword;
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/OnboardingBasedRecommendationResponse.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/OnboardingBasedRecommendationResponse.java
@@ -1,0 +1,34 @@
+package com.example.booklog.domain.onboarding.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 온보딩 기반 도서 추천 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OnboardingBasedRecommendationResponse {
+
+    /**
+     * 추천 카드 목록 (최대 6개)
+     */
+    private List<BookRecommendationCardResponse> recommendations;
+
+    /**
+     * 추천 생성에 사용된 온보딩 필드 개수
+     */
+    private int usedFieldCount;
+
+    /**
+     * 총 추천 카드 개수
+     */
+    private int totalRecommendations;
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/OnboardingProfileResponse.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/dto/OnboardingProfileResponse.java
@@ -62,5 +62,24 @@ public class OnboardingProfileResponse {
                 .completedAt(status != null ? status.getCompletedAt() : null)
                 .build();
     }
+
+    /**
+     * 빈 온보딩 프로필 응답 생성
+     * - 온보딩을 하지 않은 사용자를 위한 기본 응답
+     */
+    public static OnboardingProfileResponse empty() {
+        return OnboardingProfileResponse.builder()
+                .readerType(null)
+                .preferredMood1(null)
+                .preferredMood2(null)
+                .sentenceBreath(null)
+                .expressionTexture(null)
+                .expressionDirection(null)
+                .readingMoment(null)
+                .updatedAt(null)
+                .isCompleted(false)
+                .completedAt(null)
+                .build();
+    }
 }
 

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/service/KeywordSimilarityMatcher.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/service/KeywordSimilarityMatcher.java
@@ -1,0 +1,178 @@
+package com.example.booklog.domain.onboarding.service;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * 키워드 유사도 매칭 유틸리티
+ * - 코사인 유사도 기반 키워드 매칭
+ * - 사전 정의된 키워드 집합 관리
+ */
+@Slf4j
+@Component
+public class KeywordSimilarityMatcher {
+
+    /**
+     * 사전 정의된 분위기 키워드
+     */
+    @Getter
+    private static final List<String> MOOD_KEYWORDS = Arrays.asList(
+            "따뜻한", "잔잔한", "서늘한", "몽환적인", "유쾌한", "어두운"
+    );
+
+    /**
+     * 사전 정의된 문체 키워드
+     */
+    @Getter
+    private static final List<String> STYLE_KEYWORDS = Arrays.asList(
+            "간결한", "화려한", "담백한", "섬세한", "직설적", "은유적"
+    );
+
+    /**
+     * 사전 정의된 몰입도 키워드
+     * (SentenceBreath, ExpressionTexture, ExpressionDirection 통합)
+     */
+    @Getter
+    private static final List<String> IMMERSION_KEYWORDS = Arrays.asList(
+            "빠른 전개", "느린 전개", "긴장감 있는", "편안한",
+            "현실적", "환상적", "논리적", "감성적"
+    );
+
+    /**
+     * 한글 자모 분해 기반 간단한 유사도 계산
+     * - 실제 프로덕션에서는 Word2Vec, BERT 등 사용 권장
+     * - 여기서는 문자열 유사도 기반 간이 구현
+     */
+    public String findMostSimilarKeyword(String target, List<String> candidates) {
+        if (target == null || target.isEmpty() || candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+
+        double maxSimilarity = 0.0;
+        String bestMatch = null;
+
+        for (String candidate : candidates) {
+            double similarity = calculateSimilarity(target, candidate);
+            if (similarity > maxSimilarity) {
+                maxSimilarity = similarity;
+                bestMatch = candidate;
+            }
+        }
+
+        // 유사도가 일정 임계값 이상일 때만 반환
+        if (maxSimilarity >= 0.3) {
+            log.debug("키워드 매칭 성공 - target: {}, match: {}, similarity: {}",
+                    target, bestMatch, maxSimilarity);
+            return bestMatch;
+        }
+
+        log.debug("키워드 매칭 실패 - target: {}, maxSimilarity: {}", target, maxSimilarity);
+        return null;
+    }
+
+    /**
+     * 간단한 문자열 유사도 계산 (Jaccard similarity 기반)
+     */
+    private double calculateSimilarity(String s1, String s2) {
+        Set<Character> set1 = new HashSet<>();
+        Set<Character> set2 = new HashSet<>();
+
+        for (char c : s1.toCharArray()) {
+            set1.add(c);
+        }
+        for (char c : s2.toCharArray()) {
+            set2.add(c);
+        }
+
+        Set<Character> intersection = new HashSet<>(set1);
+        intersection.retainAll(set2);
+
+        Set<Character> union = new HashSet<>(set1);
+        union.addAll(set2);
+
+        if (union.isEmpty()) {
+            return 0.0;
+        }
+
+        return (double) intersection.size() / union.size();
+    }
+
+    /**
+     * 분위기 키워드 매칭
+     */
+    public String matchMoodKeyword(String target) {
+        return findMostSimilarKeyword(target, MOOD_KEYWORDS);
+    }
+
+    /**
+     * 문체 키워드 매칭
+     */
+    public String matchStyleKeyword(String target) {
+        return findMostSimilarKeyword(target, STYLE_KEYWORDS);
+    }
+
+    /**
+     * 몰입도 키워드 매칭
+     */
+    public String matchImmersionKeyword(String target) {
+        return findMostSimilarKeyword(target, IMMERSION_KEYWORDS);
+    }
+
+    /**
+     * Enum 값을 한글 설명으로 변환하는 헬퍼 메서드
+     */
+    public String getEnumDescription(Object enumValue) {
+        if (enumValue == null) {
+            return null;
+        }
+
+        try {
+            // Enum의 getDescription() 또는 getLabel() 메서드 호출
+            var method = enumValue.getClass().getMethod("getDescription");
+            return (String) method.invoke(enumValue);
+        } catch (NoSuchMethodException e) {
+            try {
+                var method = enumValue.getClass().getMethod("getLabel");
+                return (String) method.invoke(enumValue);
+            } catch (Exception ex) {
+                return enumValue.toString();
+            }
+        } catch (Exception e) {
+            log.warn("Enum 설명 조회 실패: {}", e.getMessage());
+            return enumValue.toString();
+        }
+    }
+
+    /**
+     * Enum 값을 핵심 단어(label)로 변환하는 헬퍼 메서드
+     * PreferredMood -> getDescription() 반환 (예: "따뜻한")
+     * SentenceBreath/ExpressionTexture/ExpressionDirection -> getLabel() 반환 (예: "간결한")
+     */
+    public String getEnumLabel(Object enumValue) {
+        if (enumValue == null) {
+            return null;
+        }
+
+        try {
+            // 1. getLabel() 메서드 우선 시도 (문체 관련 Enum)
+            var labelMethod = enumValue.getClass().getMethod("getLabel");
+            return (String) labelMethod.invoke(enumValue);
+        } catch (NoSuchMethodException e) {
+            try {
+                // 2. getDescription() 메서드 시도 (분위기 관련 Enum)
+                var descMethod = enumValue.getClass().getMethod("getDescription");
+                return (String) descMethod.invoke(enumValue);
+            } catch (Exception ex) {
+                log.warn("Enum label 조회 실패, toString 사용: {}", enumValue);
+                return enumValue.toString();
+            }
+        } catch (Exception e) {
+            log.warn("Enum label 조회 실패: {}", e.getMessage());
+            return enumValue.toString();
+        }
+    }
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/service/OnboardingRecommendationService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/service/OnboardingRecommendationService.java
@@ -1,0 +1,543 @@
+package com.example.booklog.domain.onboarding.service;
+
+import com.example.booklog.domain.ai.entity.GptRecommendationRequest;
+import com.example.booklog.domain.ai.entity.GptRecommendationResponse;
+import com.example.booklog.domain.ai.service.GptService;
+import com.example.booklog.domain.library.books.dto.KakaoBookSearchResponse;
+import com.example.booklog.domain.library.books.entity.Books;
+import com.example.booklog.domain.library.books.repository.BooksRepository;
+import com.example.booklog.domain.library.books.service.client.KakaoBookClient;
+import com.example.booklog.domain.library.shelves.entity.UserBooks;
+import com.example.booklog.domain.library.shelves.repository.UserBooksRepository;
+import com.example.booklog.domain.onboarding.dto.BookRecommendationCardResponse;
+import com.example.booklog.domain.onboarding.dto.OnboardingBasedRecommendationResponse;
+import com.example.booklog.domain.onboarding.entity.UserReadingProfile;
+import com.example.booklog.domain.onboarding.repository.UserReadingProfileRepository;
+import com.example.booklog.domain.search.entity.SearchKeyword;
+import com.example.booklog.domain.search.repository.SearchKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 온보딩 기반 도서 추천 서비스
+ * - 사용자의 온보딩 키워드 + 최근 검색어를 바탕으로 도서 추천
+ * - GPT를 통한 작가/장르 추론
+ * - Kakao Book API를 통한 도서 검색
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OnboardingRecommendationService {
+
+    private final UserReadingProfileRepository profileRepository;
+    private final SearchKeywordRepository searchKeywordRepository;
+    private final UserBooksRepository userBooksRepository;
+    private final BooksRepository booksRepository;
+    private final GptService gptService;
+    private final KakaoBookClient kakaoBookClient;
+    private final KeywordSimilarityMatcher keywordMatcher;
+
+    private static final int MAX_RECOMMENDATIONS = 6;
+    private static final int RECENT_SEARCH_LIMIT = 10;
+    private static final int USER_BOOKS_ANALYSIS_LIMIT = 20; // 서재 도서 분석 개수
+
+    /**
+     * 온보딩 기반 도서 추천 생성
+     *
+     * [추천 우선순위]
+     * 1. 서재에 도서가 있으면 → 서재 도서 정보(작가, 장르) 기반 추천
+     * 2. 서재에 도서가 없고 온보딩이 있으면 → 온보딩(분위기, 문체, 몰입도) 기반 추천
+     * 3. 서재도 없고 온보딩도 스킵했으면 → 랭킹/인기 기반 추천
+     *
+     * - 추천 결과가 0개여도 200 OK 반환
+     *
+     * @param userId 사용자 ID
+     * @return 추천 카드 목록
+     */
+    @Transactional(readOnly = true)
+    public OnboardingBasedRecommendationResponse generateRecommendations(Long userId) {
+        log.info("온보딩 기반 추천 생성 시작 - userId: {}", userId);
+
+        try {
+            // 1. 서재 도서 확인
+            List<UserBooks> userBooks = userBooksRepository.list(
+                    userId,
+                    null, // 모든 서재
+                    null, // 모든 상태
+                    Sort.by(Sort.Direction.DESC, "createdAt")
+            );
+
+            // 2. 최근 검색어 조회 (모든 추천 방식에서 사용)
+            String recentSearches = getRecentSearchKeywords(userId);
+
+            // 3-1. 서재에 도서가 있으면 서재 기반 추천
+            if (!userBooks.isEmpty()) {
+                log.info("서재 기반 추천 시작 - userId: {}, 서재 도서 수: {}", userId, userBooks.size());
+                return generateLibraryBasedRecommendations(userId, userBooks, recentSearches);
+            }
+
+            // 3-2. 서재에 도서가 없으면 온보딩 확인
+            UserReadingProfile profile = profileRepository.findByUserId(userId).orElse(null);
+
+            if (profile != null && hasOnboardingData(profile)) {
+                log.info("온보딩 기반 추천 시작 - userId: {}", userId);
+                return generateOnboardingBasedRecommendations(profile, recentSearches);
+            }
+
+            // 3-3. 서재도 없고 온보딩도 없으면 인기 도서 기반 추천
+            log.info("인기 도서 기반 추천 시작 - userId: {}", userId);
+            return generatePopularBooksRecommendations();
+
+        } catch (Exception e) {
+            log.error("온보딩 기반 추천 생성 중 오류 발생 - userId: {}, error: {}",
+                    userId, e.getMessage(), e);
+            // 예외 발생 시에도 빈 결과 반환 (500 에러 방지)
+            return buildEmptyResponse();
+        }
+    }
+
+    /**
+     * 온보딩 데이터가 있는지 확인
+     */
+    private boolean hasOnboardingData(UserReadingProfile profile) {
+        return profile.getPreferredMood1() != null
+                || profile.getPreferredMood2() != null
+                || profile.getSentenceBreath() != null
+                || profile.getExpressionTexture() != null
+                || profile.getExpressionDirection() != null;
+    }
+
+    /**
+     * 서재 기반 추천 생성
+     * - 서재 도서의 작가, 장르 정보를 분석하여 유사 도서 추천
+     */
+    private OnboardingBasedRecommendationResponse generateLibraryBasedRecommendations(
+            Long userId,
+            List<UserBooks> userBooks,
+            String recentSearches) {
+
+        List<BookRecommendationCardResponse> recommendations = new ArrayList<>();
+        int processedCount = 0;
+
+        // 서재 도서에서 작가 추출 (최대 분석 개수 제한)
+        List<UserBooks> booksToAnalyze = userBooks.stream()
+                .limit(USER_BOOKS_ANALYSIS_LIMIT)
+                .toList();
+
+        for (UserBooks userBook : booksToAnalyze) {
+            if (processedCount >= MAX_RECOMMENDATIONS) {
+                break;
+            }
+
+            try {
+                Books book = userBook.getBook();
+
+                // 작가 정보 추출
+                String authorInfo = book.getBookAuthors().stream()
+                        .filter(ba -> ba.getRole() == com.example.booklog.domain.library.books.entity.AuthorRole.AUTHOR)
+                        .map(ba -> ba.getAuthor().getName())
+                        .collect(Collectors.joining(", "));
+
+                if (authorInfo.isEmpty()) {
+                    continue;
+                }
+
+                // GPT를 통해 유사 작가/장르 도서 추천
+                BookRecommendationCardResponse card = generateLibraryBasedCard(
+                        book.getTitle(),
+                        authorInfo,
+                        recentSearches
+                );
+
+                if (card != null) {
+                    recommendations.add(card);
+                    processedCount++;
+                }
+
+            } catch (Exception e) {
+                log.error("서재 기반 추천 카드 생성 실패 - bookId: {}, error: {}",
+                        userBook.getBook().getId(), e.getMessage());
+                // 개별 카드 실패는 무시하고 계속 진행
+            }
+        }
+
+        log.info("서재 기반 추천 완료 - userId: {}, count: {}", userId, recommendations.size());
+
+        return OnboardingBasedRecommendationResponse.builder()
+                .recommendations(recommendations)
+                .usedFieldCount(booksToAnalyze.size())
+                .totalRecommendations(recommendations.size())
+                .build();
+    }
+
+    /**
+     * 서재 기반 개별 추천 카드 생성
+     */
+    private BookRecommendationCardResponse generateLibraryBasedCard(
+            String bookTitle,
+            String authorInfo,
+            String recentSearches) {
+
+        // GPT 호출 - 서재 도서 기반 유사 도서 추천
+        GptRecommendationRequest gptRequest = GptRecommendationRequest.builder()
+                .fieldName("library_book")
+                .fieldValue(bookTitle)
+                .fieldDescription("작가: " + authorInfo)
+                .recentSearchKeywords(recentSearches)
+                .build();
+
+        GptRecommendationResponse gptResponse = gptService.generateRecommendationKeyword(gptRequest);
+
+        // Kakao Book API 호출
+        String searchKeyword = gptResponse.getSearchKeyword();
+        KakaoBookSearchResponse kakaoResponse = kakaoBookClient
+                .search(searchKeyword, 1, 5)
+                .block();
+
+        if (kakaoResponse == null || kakaoResponse.getDocuments() == null
+                || kakaoResponse.getDocuments().isEmpty()) {
+            log.warn("Kakao API 검색 결과 없음 - keyword: {}", searchKeyword);
+            return null;
+        }
+
+        KakaoBookSearchResponse.Document recommendedBook = kakaoResponse.getDocuments().get(0);
+
+        // 추천된 도서의 키워드 분석 (GPT 호출)
+        String recommendedAuthor = recommendedBook.getAuthors() != null && !recommendedBook.getAuthors().isEmpty()
+                ? String.join(", ", recommendedBook.getAuthors()) : "저자 미상";
+
+        Map<String, String> keywords = gptService.analyzeBookKeywords(
+                recommendedBook.getTitle(),
+                recommendedAuthor,
+                recommendedBook.getPublisher()
+        );
+
+        return BookRecommendationCardResponse.builder()
+                .bookTitle(recommendedBook.getTitle())
+                .author(recommendedAuthor)
+                .publisher(recommendedBook.getPublisher())
+                .thumbnailUrl(recommendedBook.getThumbnail())
+                .recommendationSourceField("library_book")
+                .recommendationSourceValue(bookTitle)
+                .moodKeyword(keywords.get("mood"))
+                .styleKeyword(keywords.get("style"))
+                .immersionKeyword(keywords.get("immersion"))
+                .build();
+    }
+
+    /**
+     * 온보딩 기반 추천 생성 (기존 로직)
+     */
+    private OnboardingBasedRecommendationResponse generateOnboardingBasedRecommendations(
+            UserReadingProfile profile,
+            String recentSearches) {
+
+        // 추천 기준 필드 추출
+        List<RecommendationCriteria> criteriaList = extractRecommendationCriteria(profile);
+
+        if (criteriaList.isEmpty()) {
+            log.info("추천 기준 필드 없음 (모두 null) - 빈 추천 반환");
+            return buildEmptyResponse();
+        }
+
+        // 각 기준별로 추천 카드 생성 (최대 6개)
+        List<BookRecommendationCardResponse> recommendations = new ArrayList<>();
+        int processedCount = 0;
+
+        for (RecommendationCriteria criteria : criteriaList) {
+            if (processedCount >= MAX_RECOMMENDATIONS) {
+                break;
+            }
+
+            try {
+                BookRecommendationCardResponse card = generateOnboardingBasedCard(
+                        criteria, recentSearches, profile);
+
+                if (card != null) {
+                    recommendations.add(card);
+                    processedCount++;
+                }
+            } catch (Exception e) {
+                log.error("추천 카드 생성 실패 - field: {}, error: {}",
+                        criteria.getFieldName(), e.getMessage(), e);
+                // 개별 카드 실패는 무시하고 계속 진행
+            }
+        }
+
+        log.info("온보딩 기반 추천 생성 완료 - count: {}", recommendations.size());
+
+        return OnboardingBasedRecommendationResponse.builder()
+                .recommendations(recommendations)
+                .usedFieldCount(criteriaList.size())
+                .totalRecommendations(recommendations.size())
+                .build();
+    }
+
+    /**
+     * 인기 도서 기반 추천 (서재도 없고 온보딩도 스킵한 경우)
+     */
+    private OnboardingBasedRecommendationResponse generatePopularBooksRecommendations() {
+        try {
+            // 최근 출판된 인기 도서 조회 (publishedDate 기준 최신순)
+            PageRequest pageRequest = PageRequest.of(0, MAX_RECOMMENDATIONS,
+                    Sort.by(Sort.Direction.DESC, "publishedDate").and(Sort.by(Sort.Direction.DESC, "id")));
+
+            List<Books> popularBooks = booksRepository.findAll(pageRequest).getContent();
+
+            List<BookRecommendationCardResponse> recommendations = popularBooks.stream()
+                    .map(book -> {
+                        String authorInfo = book.getBookAuthors().stream()
+                                .filter(ba -> ba.getRole() == com.example.booklog.domain.library.books.entity.AuthorRole.AUTHOR)
+                                .map(ba -> ba.getAuthor().getName())
+                                .collect(Collectors.joining(", "));
+
+                        String author = authorInfo.isEmpty() ? "저자 미상" : authorInfo;
+
+                        // GPT를 통한 키워드 분석
+                        Map<String, String> keywords = gptService.analyzeBookKeywords(
+                                book.getTitle(),
+                                author,
+                                book.getPublisherName()
+                        );
+
+                        return BookRecommendationCardResponse.builder()
+                                .bookTitle(book.getTitle())
+                                .author(author)
+                                .publisher(book.getPublisherName())
+                                .thumbnailUrl(book.getThumbnailUrl())
+                                .recommendationSourceField("popular_ranking")
+                                .recommendationSourceValue("최신 인기 도서")
+                                .moodKeyword(keywords.get("mood"))
+                                .styleKeyword(keywords.get("style"))
+                                .immersionKeyword(keywords.get("immersion"))
+                                .build();
+                    })
+                    .toList();
+
+            log.info("인기 도서 기반 추천 완료 - count: {}", recommendations.size());
+
+            return OnboardingBasedRecommendationResponse.builder()
+                    .recommendations(recommendations)
+                    .usedFieldCount(0)
+                    .totalRecommendations(recommendations.size())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("인기 도서 기반 추천 실패 - error: {}", e.getMessage(), e);
+            return buildEmptyResponse();
+        }
+    }
+
+    /**
+     * 온보딩 기반 개별 추천 카드 생성
+     */
+    private BookRecommendationCardResponse generateOnboardingBasedCard(
+            RecommendationCriteria criteria,
+            String recentSearches,
+            UserReadingProfile profile) {
+
+        log.debug("추천 카드 생성 - field: {}, value: {}",
+                criteria.getFieldName(), criteria.getFieldValue());
+
+        // 1. GPT 호출 - 작가/장르 추론
+        GptRecommendationRequest gptRequest = GptRecommendationRequest.builder()
+                .fieldName(criteria.getFieldName())
+                .fieldValue(criteria.getFieldValue())
+                .fieldDescription(criteria.getFieldDescription())
+                .recentSearchKeywords(recentSearches)
+                .build();
+
+        GptRecommendationResponse gptResponse = gptService.generateRecommendationKeyword(gptRequest);
+
+        // 2. Kakao Book API 호출
+        String searchKeyword = gptResponse.getSearchKeyword();
+        KakaoBookSearchResponse kakaoResponse = kakaoBookClient
+                .search(searchKeyword, 1, 5)
+                .block();
+
+        if (kakaoResponse == null || kakaoResponse.getDocuments() == null
+                || kakaoResponse.getDocuments().isEmpty()) {
+            log.warn("Kakao API 검색 결과 없음 - keyword: {}", searchKeyword);
+            return null;
+        }
+
+        // 3. 첫 번째 도서 선택
+        KakaoBookSearchResponse.Document book = kakaoResponse.getDocuments().get(0);
+
+        // 4. 키워드 보정
+        String moodKeyword = determineKeyword(profile.getPreferredMood1(),
+                profile.getPreferredMood2(), "mood");
+        String styleKeyword = determineKeyword(profile.getSentenceBreath(),
+                profile.getExpressionTexture(), "style");
+        String immersionKeyword = determineKeyword(profile.getExpressionDirection(),
+                profile.getSentenceBreath(), "immersion");
+
+        // 5. 추천 카드 DTO 생성
+        return BookRecommendationCardResponse.builder()
+                .bookTitle(book.getTitle())
+                .author(book.getAuthors() != null && !book.getAuthors().isEmpty()
+                        ? String.join(", ", book.getAuthors()) : "저자 미상")
+                .publisher(book.getPublisher())
+                .thumbnailUrl(book.getThumbnail())
+                .recommendationSourceField(criteria.getFieldName())
+                .recommendationSourceValue(criteria.getFieldValue())
+                .moodKeyword(moodKeyword)
+                .styleKeyword(styleKeyword)
+                .immersionKeyword(immersionKeyword)
+                .build();
+    }
+
+    /**
+     * 키워드 결정 로직
+     * 1. 사용자가 선택한 키워드가 있으면 핵심 단어만 사용 (label)
+     * 2. 없으면 코사인 유사도로 매칭
+     * 3. 매칭 실패 시 null
+     */
+    private String determineKeyword(Object primaryEnum, Object secondaryEnum, String type) {
+        // 1차 키워드가 있으면 사용 (핵심 단어만)
+        if (primaryEnum != null) {
+            return keywordMatcher.getEnumLabel(primaryEnum);
+        }
+
+        // 2차 키워드가 있으면 사용
+        if (secondaryEnum != null) {
+            String label = keywordMatcher.getEnumLabel(secondaryEnum);
+
+            // 타입별 유사도 매칭
+            return switch (type) {
+                case "mood" -> keywordMatcher.matchMoodKeyword(label);
+                case "style" -> keywordMatcher.matchStyleKeyword(label);
+                case "immersion" -> keywordMatcher.matchImmersionKeyword(label);
+                default -> label;
+            };
+        }
+
+        return null;
+    }
+
+    /**
+     * 최근 검색어 조회
+     */
+    private String getRecentSearchKeywords(Long userId) {
+        try {
+            List<SearchKeyword> recentSearches = searchKeywordRepository
+                    .findByUserIdOrderByCreatedAtDesc(userId, PageRequest.of(0, RECENT_SEARCH_LIMIT));
+
+            if (recentSearches.isEmpty()) {
+                return "";
+            }
+
+            return recentSearches.stream()
+                    .map(SearchKeyword::getKeyword)
+                    .collect(Collectors.joining(", "));
+
+        } catch (Exception e) {
+            log.warn("최근 검색어 조회 실패 - userId: {}, error: {}", userId, e.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * 추천 기준 필드 추출
+     * - null이 아닌 필드만 추출
+     * - 최대 6개
+     */
+    private List<RecommendationCriteria> extractRecommendationCriteria(UserReadingProfile profile) {
+        List<RecommendationCriteria> criteria = new ArrayList<>();
+
+        // preferredMood1
+        if (profile.getPreferredMood1() != null) {
+            criteria.add(new RecommendationCriteria(
+                    "preferredMood1",
+                    profile.getPreferredMood1().name(),
+                    profile.getPreferredMood1().getDescription()
+            ));
+        }
+
+        // preferredMood2
+        if (profile.getPreferredMood2() != null && criteria.size() < MAX_RECOMMENDATIONS) {
+            criteria.add(new RecommendationCriteria(
+                    "preferredMood2",
+                    profile.getPreferredMood2().name(),
+                    profile.getPreferredMood2().getDescription()
+            ));
+        }
+
+        // sentenceBreath
+        if (profile.getSentenceBreath() != null && criteria.size() < MAX_RECOMMENDATIONS) {
+            criteria.add(new RecommendationCriteria(
+                    "sentenceBreath",
+                    profile.getSentenceBreath().name(),
+                    profile.getSentenceBreath().getLabel()
+            ));
+        }
+
+        // expressionTexture
+        if (profile.getExpressionTexture() != null && criteria.size() < MAX_RECOMMENDATIONS) {
+            criteria.add(new RecommendationCriteria(
+                    "expressionTexture",
+                    profile.getExpressionTexture().name(),
+                    profile.getExpressionTexture().getLabel()
+            ));
+        }
+
+        // expressionDirection
+        if (profile.getExpressionDirection() != null && criteria.size() < MAX_RECOMMENDATIONS) {
+            criteria.add(new RecommendationCriteria(
+                    "expressionDirection",
+                    profile.getExpressionDirection().name(),
+                    profile.getExpressionDirection().getLabel()
+            ));
+        }
+
+        return criteria;
+    }
+
+    /**
+     * 빈 추천 응답 생성
+     */
+    private OnboardingBasedRecommendationResponse buildEmptyResponse() {
+        return OnboardingBasedRecommendationResponse.builder()
+                .recommendations(List.of())
+                .usedFieldCount(0)
+                .totalRecommendations(0)
+                .build();
+    }
+
+    /**
+     * 추천 기준 내부 클래스
+     */
+    private static class RecommendationCriteria {
+        private final String fieldName;
+        private final String fieldValue;
+        private final String fieldDescription;
+
+        public RecommendationCriteria(String fieldName, String fieldValue, String fieldDescription) {
+            this.fieldName = fieldName;
+            this.fieldValue = fieldValue;
+            this.fieldDescription = fieldDescription;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public String getFieldValue() {
+            return fieldValue;
+        }
+
+        public String getFieldDescription() {
+            return fieldDescription;
+        }
+    }
+}
+

--- a/booklog/src/main/java/com/example/booklog/domain/onboarding/service/OnboardingService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/onboarding/service/OnboardingService.java
@@ -101,11 +101,20 @@ public class OnboardingService {
 
     /**
      * 온보딩 프로필 조회
+     * - 프로필이 없는 경우 빈 응답 반환 (200 OK)
+     * - 500 에러를 발생시키지 않음
+     *
      * @param userId 인증된 사용자 ID
+     * @return 온보딩 프로필 응답 (없으면 빈 응답)
      */
     public OnboardingProfileResponse getOnboardingProfile(Long userId) {
         UserReadingProfile profile = profileRepository.findByUserId(userId)
-                .orElseThrow(() -> new OnboardingProfileNotFoundException());
+                .orElse(null);
+
+        // 프로필이 없으면 빈 응답 반환
+        if (profile == null) {
+            return OnboardingProfileResponse.empty();
+        }
 
         UserOnboardingStatus status = statusRepository.findByUserId(userId).orElse(null);
 

--- a/booklog/src/main/java/com/example/booklog/global/config/GptConfig.java
+++ b/booklog/src/main/java/com/example/booklog/global/config/GptConfig.java
@@ -1,0 +1,30 @@
+package com.example.booklog.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GptConfig {
+
+    @Value("${spring.openai.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.openai.model}")
+    private String model;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+}
+

--- a/booklog/src/main/resources/application.yaml
+++ b/booklog/src/main/resources/application.yaml
@@ -55,8 +55,8 @@ spring:
       enable-statistics: true
   #AI
   openai:
-    model: gpt-4o-mini
-    secret-key: ${GPT_SECRET_API_KEY}
+    model: ${OPENAI_MODEL:gpt-4o-mini}
+    secret-key: ${GPT_SECRET_API_KEY:dummy-key-for-development}
   # OAuth2 소셜 로그인 설정 (카카오)
   security:
     oauth2:


### PR DESCRIPTION
홈 화면 상단에 있는 내가 좋아하는 ~ 책 추천 기능입니다.
사용한 AI 모델은 gpt-4o-mini이고, 책 정보는 카카오 API KEY를 이용하였습니다.

1. 사용자 서재가 있는 경우 -> 서재를 바탕으로 책을 추천
2. 서재가 없는 경우, 온보딩을 기준으로 책 추천
3. 둘 다 없는 경우, 인기 도서 기준으로 책 추천

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New personalized recommendations endpoint using onboarding data, library history, and popularity fallback.
  * AI-powered keyword generation and book analysis (author/genre keywords; mood/style/immersion) to improve matching.
  * Configurable OpenAI model/key with sensible defaults for local/dev setups.

* **Bug Fixes**
  * Graceful handling for users without onboarding profiles—returns an empty profile rather than throwing an error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->