### PR TITLE
FEAT :  내 북로그 조회 / 내 북마크 피드 목록 조회 / 다른 유저 북로그 조회 api 추가

### DIFF
--- a/booklog/src/main/java/com/example/booklog/domain/booklog/repository/BooklogBookmarkRepository.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/repository/BooklogBookmarkRepository.java
@@ -1,8 +1,10 @@
 package com.example.booklog.domain.booklog.repository;
 
 import com.example.booklog.domain.booklog.entity.BooklogBookmark;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,15 +21,29 @@ public interface BooklogBookmarkRepository extends JpaRepository<BooklogBookmark
         where b.postId in :postIds
         group by b.postId
     """)
-    List<Object[]> countByPostIds(List<Long> postIds);
+    List<Object[]> countByPostIds(@Param("postIds") List<Long> postIds);
 
     @Query("""
-    select b.postId
-    from BooklogBookmark b
-    where b.userId = :userId
-      and b.postId in :postIds
-""")
-    List<Long> findBookmarkedPostIdsByUserIdInPostIds(Long userId, List<Long> postIds);
+        select b.postId
+        from BooklogBookmark b
+        where b.userId = :userId
+          and b.postId in :postIds
+    """)
+    List<Long> findBookmarkedPostIdsByUserIdInPostIds(
+            @Param("userId") Long userId,
+            @Param("postIds") List<Long> postIds
+    );
+
+    @Query("""
+        select b.postId
+        from BooklogBookmark b
+        where b.userId = :userId
+        order by b.id desc
+    """)
+    List<Long> findMyBookmarkedPostIds(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
     void deleteByUserIdAndPostId(Long userId, Long postId);
 

--- a/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogPostServiceImpl.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogPostServiceImpl.java
@@ -333,4 +333,5 @@ public class BooklogPostServiceImpl implements BooklogPostService {
             throw e;
         }
     }
+
 }

--- a/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacade.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacade.java
@@ -1,6 +1,7 @@
 package com.example.booklog.domain.booklog.service;
 
 import com.example.booklog.domain.booklog.dto.BooklogFeedQuery;
+import com.example.booklog.domain.booklog.dto.BooklogFeedResponse;
 import com.example.booklog.domain.booklog.dto.BooklogRecommendationResponse;
 import com.example.booklog.domain.booklog.entity.BooklogPost;
 import com.example.booklog.domain.booklog.view.AuthorView;
@@ -28,4 +29,5 @@ public interface BooklogReadFacade {
     Slice<BooklogPost> findFeedPostsSlice(BooklogFeedQuery query, Pageable pageable);
     BooklogRecommendationResponse buildRecommendations(Long postId);
     void validateCreateRequest(Long userId, Long bookId);
+    BooklogFeedResponse assembleFeedCards(Long viewerId, Slice<BooklogPost> slice);
 }

--- a/booklog/src/main/java/com/example/booklog/domain/users/controller/MeBooklogController.java
+++ b/booklog/src/main/java/com/example/booklog/domain/users/controller/MeBooklogController.java
@@ -1,0 +1,43 @@
+package com.example.booklog.domain.users.controller;
+
+import com.example.booklog.domain.booklog.dto.BooklogFeedResponse;
+import com.example.booklog.domain.users.service.UserBooklogReadService;
+import com.example.booklog.global.auth.exception.AuthSuccessCode;
+import com.example.booklog.global.auth.security.CustomUserDetails;
+import com.example.booklog.global.common.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "마이페이지(Me) - Booklogs", description = "내 북로그/북마크 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/me")
+public class MeBooklogController {
+
+    private final UserBooklogReadService userBooklogReadService;
+
+    @Operation(summary = "내 북로그 조회")
+    @GetMapping("/booklogs")
+    public ApiResponse<BooklogFeedResponse> myBooklogs(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @ParameterObject Pageable pageable
+    ) {
+        BooklogFeedResponse res = userBooklogReadService.getMyBooklogs(me.getUserId(), pageable);
+        return ApiResponse.onSuccess(AuthSuccessCode.READ_SUCCESS, res);
+    }
+
+    @Operation(summary = "내 북마크한 북로그 조회")
+    @GetMapping("/booklogs/bookmarks")
+    public ApiResponse<BooklogFeedResponse> myBookmarkedBooklogs(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @ParameterObject Pageable pageable
+    ) {
+        BooklogFeedResponse res = userBooklogReadService.getMyBookmarkedBooklogs(me.getUserId(), pageable);
+        return ApiResponse.onSuccess(AuthSuccessCode.READ_SUCCESS, res);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/domain/users/controller/UserBooklogController.java
+++ b/booklog/src/main/java/com/example/booklog/domain/users/controller/UserBooklogController.java
@@ -1,0 +1,38 @@
+package com.example.booklog.domain.users.controller;
+
+import com.example.booklog.domain.booklog.dto.BooklogFeedResponse;
+import com.example.booklog.domain.users.service.UserBooklogReadService;
+import com.example.booklog.global.auth.exception.AuthSuccessCode;
+import com.example.booklog.global.auth.security.CustomUserDetails;
+import com.example.booklog.global.common.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "유저(User) - Booklogs", description = "다른 유저 북로그 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserBooklogController {
+
+    private final UserBooklogReadService userBooklogReadService;
+
+    @Operation(summary = "다른 유저 공개 북로그 조회")
+    @GetMapping("/{userId}/booklogs")
+    public ApiResponse<BooklogFeedResponse> getUserBooklogs(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @PathVariable Long userId,
+            @ParameterObject Pageable pageable
+    ) {
+        BooklogFeedResponse res = userBooklogReadService.getUserPublicBooklogs(
+                me.getUserId(),
+                userId,
+                pageable
+        );
+        return ApiResponse.onSuccess(AuthSuccessCode.READ_SUCCESS, res);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/domain/users/service/MeAvatarService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/users/service/MeAvatarService.java
@@ -9,6 +9,7 @@ import com.example.booklog.global.common.apiPayload.code.status.ErrorStatus;
 import com.example.booklog.global.common.apiPayload.exception.GeneralException;
 import com.example.booklog.global.common.repository.UuidRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Set;
 import java.util.UUID;
 
+@Profile("!local")
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/booklog/src/main/java/com/example/booklog/domain/users/service/UserBooklogReadService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/users/service/UserBooklogReadService.java
@@ -1,0 +1,133 @@
+package com.example.booklog.domain.users.service;
+
+import com.example.booklog.domain.booklog.dto.BooklogFeedResponse;
+import com.example.booklog.domain.booklog.entity.BooklogPost;
+import com.example.booklog.domain.booklog.entity.BooklogStatus;
+import com.example.booklog.domain.booklog.repository.BooklogBookmarkRepository;
+import com.example.booklog.domain.booklog.repository.BooklogPostRepository;
+import com.example.booklog.domain.booklog.service.BooklogReadFacade;
+import com.example.booklog.domain.users.entity.UserSettings;
+import com.example.booklog.domain.users.repository.UserSettingsRepository;
+import com.example.booklog.domain.users.repository.UsersRepository;
+import com.example.booklog.global.common.apiPayload.code.generalStatus.GeneralErrorCode;
+import com.example.booklog.global.common.apiPayload.code.status.ErrorStatus;
+import com.example.booklog.global.common.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserBooklogReadService {
+
+    private final UsersRepository usersRepository;
+    private final UserSettingsRepository userSettingsRepository;
+
+    private final BooklogPostRepository postRepository;
+    private final BooklogBookmarkRepository bookmarkRepository;
+
+    private final BooklogReadFacade booklogReadFacade;
+
+    /**
+     * 다른 유저 공개 북로그 조회
+     */
+    @Transactional(readOnly = true)
+    public BooklogFeedResponse getUserPublicBooklogs(Long viewerId, Long targetUserId, Pageable pageable) {
+
+        // 1) 유저 존재
+        if (!usersRepository.existsById(targetUserId)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        // 2) 공개 토글 확인 (settings 없으면 기본 공개 정책이면 true로)
+        UserSettings settings = userSettingsRepository.findById(targetUserId).orElse(null);
+        boolean isPostPublic = (settings == null) ? true : Boolean.TRUE.equals(settings.getIsPostPublic());
+
+        if (!isPostPublic) {
+            // 정책 선택:
+            // - 403이 더 정확
+            // - 또는 존재 자체 숨기려면 404로 처리
+            throw new AccessDeniedException("권한이 없습니다.");
+        }
+
+        // 3) slice 조회
+        Slice<BooklogPost> slice = postRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
+                targetUserId,
+                BooklogStatus.PUBLISHED,
+                pageable
+        );
+
+        // 4) 공용 조립
+        return booklogReadFacade.assembleFeedCards(viewerId, slice);
+    }
+
+    /**
+     * 내 북로그 조회
+     */
+    @Transactional(readOnly = true)
+    public BooklogFeedResponse getMyBooklogs(Long meId, Pageable pageable) {
+
+        Slice<BooklogPost> slice = postRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
+                meId,
+                BooklogStatus.PUBLISHED,
+                pageable
+        );
+
+        return booklogReadFacade.assembleFeedCards(meId, slice);
+    }
+
+    /**
+     * 내 북마크한 북로그 조회
+     * - 북마크 테이블에서 postId를 최신순(id desc)으로 뽑고
+     * - posts를 조회한 후, bookmark 순서대로 정렬해서 slice를 만든다
+     */
+    @Transactional(readOnly = true)
+    public BooklogFeedResponse getMyBookmarkedBooklogs(Long meId, Pageable pageable) {
+
+        // (1) bookmark 테이블에서 postIds 최신순
+        // hasNext 판단 위해 size+1로 뽑는 게 좋아서 Pageable을 강제 조정
+        int size = pageable.getPageSize();
+        Pageable plusOne = PageRequest.of(pageable.getPageNumber(), size + 1);
+
+        List<Long> postIds = bookmarkRepository.findMyBookmarkedPostIds(meId, plusOne);
+
+        boolean hasNext = postIds.size() > size;
+        List<Long> slicedIds = hasNext ? postIds.subList(0, size) : postIds;
+
+        if (slicedIds.isEmpty()) {
+            return BooklogFeedResponse.builder()
+                    .items(List.of())
+                    .hasNext(false)
+                    .build();
+        }
+
+        // (2) 게시글 조회 (PUBLISHED만)
+        // 주의: findAllByIdIn...은 createdAt desc 정렬이라 bookmark 순서와 달라질 수 있음
+        // 그래서 "bookmark 순서" 유지하려면 id 리스트 기반으로 재정렬해야 함.
+        List<BooklogPost> fetched = postRepository.findAllById(slicedIds);
+
+        Map<Long, BooklogPost> map = new HashMap<>();
+        for (BooklogPost p : fetched) {
+            // DELETED일 수도 있으니 필터
+            if (p.getStatus() == BooklogStatus.PUBLISHED) {
+                map.put(p.getId(), p);
+            }
+        }
+
+        List<BooklogPost> ordered = new ArrayList<>();
+        for (Long id : slicedIds) {
+            BooklogPost p = map.get(id);
+            if (p != null) ordered.add(p);
+        }
+
+        // (3) Slice로 감싸기
+        Slice<BooklogPost> slice = new SliceImpl<>(ordered, pageable, hasNext);
+
+        // (4) 공용 조립
+        return booklogReadFacade.assembleFeedCards(meId, slice);
+    }
+}


### PR DESCRIPTION
- 내 북로그 조회 API 추가
- 내 북마크한 북로그 조회 API 추가
- 다른 유저의 공개 북로그 조회 API 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve and browse their personal booklogs through a dedicated API endpoint.
  * Users can access and review their bookmarked booklogs with pagination support.
  * Support for viewing other users' public booklogs with full pagination capabilities.
  * Enhanced feed response formatting with post details and bookmark information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->