### PR TITLE
feat: 홈 ‘지금 읽고 있는 책’ 조회 API 추가

### DIFF
--- a/booklog/src/main/java/com/example/booklog/domain/library/shelves/controller/UserBooksController.java
+++ b/booklog/src/main/java/com/example/booklog/domain/library/shelves/controller/UserBooksController.java
@@ -145,6 +145,26 @@ public class UserBooksController {
     }
 
     @Operation(
+            summary = "홈 - 지금 읽고 있는 책 조회",
+            description = """
+                홈 화면의 '지금 읽고 있는 책' 섹션용 API입니다.
+                - 인증: Access Token(Bearer)
+                - Query:
+                  - limit: 선택(기본 10, 최대 20)
+                - 응답:
+                  - count: 읽는 중 총 개수
+                  - items: 카드 리스트(제목/저자/출판사/썸네일/진행률 포함)
+                """
+    )
+    @GetMapping("/reading-books")
+    public CurrentReadingResponse currentReading(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(name = "limit", required = false, defaultValue = "10") int limit
+    ) {
+        return userBooksService.currentReading(userDetails.getUserId(), limit);
+    }
+
+    @Operation(
             summary = "도서 총 페이지 입력",
             description = """
                 사용자가 직접 입력하는 총 페이지 수(pageCountSnapshot)를 저장합니다.

--- a/booklog/src/main/java/com/example/booklog/domain/library/shelves/dto/CurrentReadingResponse.java
+++ b/booklog/src/main/java/com/example/booklog/domain/library/shelves/dto/CurrentReadingResponse.java
@@ -1,0 +1,8 @@
+package com.example.booklog.domain.library.shelves.dto;
+
+import java.util.List;
+
+public record CurrentReadingResponse(
+        long count, // 읽는 중 총 개수
+        List<UserBookListItemResponse> items // 홈 카드 리스트
+) {}

--- a/booklog/src/main/java/com/example/booklog/domain/library/shelves/repository/UserBooksRepository.java
+++ b/booklog/src/main/java/com/example/booklog/domain/library/shelves/repository/UserBooksRepository.java
@@ -3,6 +3,7 @@ package com.example.booklog.domain.library.shelves.repository;
 import com.example.booklog.domain.library.shelves.dto.UserBookListItemResponse;
 import com.example.booklog.domain.library.shelves.entity.ReadingStatus;
 import com.example.booklog.domain.library.shelves.entity.UserBooks;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
@@ -169,5 +170,34 @@ public interface UserBooksRepository extends JpaRepository<UserBooks, Long> {
     List<Long> findBookIdsByUserIdAndShelfIdAndStatus(@Param("userId") Long userId,
                                                       @Param("shelfId") Long shelfId,
                                                       @Param("status") ReadingStatus status);
+
+    @Query("""
+select new com.example.booklog.domain.library.shelves.dto.UserBookListItemResponse(
+    ub.id,
+    ub.status,
+    ub.progressPercent,
+    ub.currentPage,
+
+    b.id,
+    b.title,
+    b.thumbnailUrl,
+    b.publisherName,
+
+    a.name
+)
+from UserBooks ub
+join ub.book b
+left join b.bookAuthors ba
+    on ba.role = com.example.booklog.domain.library.books.entity.AuthorRole.AUTHOR
+    and ba.displayOrder = 1
+left join ba.author a
+where ub.user.id = :userId
+  and ub.status = com.example.booklog.domain.library.shelves.entity.ReadingStatus.READING
+order by ub.updatedAt desc
+""")
+    List<UserBookListItemResponse> listCurrentReading(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
 }

--- a/booklog/src/main/java/com/example/booklog/domain/library/shelves/service/UserBooksService.java
+++ b/booklog/src/main/java/com/example/booklog/domain/library/shelves/service/UserBooksService.java
@@ -14,6 +14,7 @@ import com.example.booklog.domain.users.repository.UsersRepository;
 import com.example.booklog.global.common.apiPayload.code.status.ErrorStatus;
 import com.example.booklog.global.common.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -315,5 +316,20 @@ public class UserBooksService {
 
         ub.setTotalPages(total);
 
+    }
+
+    public CurrentReadingResponse currentReading(Long userId, int limit) {
+        int safeLimit = Math.min(Math.max(limit, 1), 20); // 1~20 제한
+
+        // 읽는 중 총 개수(홈 문구용)
+        long count = userBooksRepository.countByFilter(userId, null, ReadingStatus.READING);
+
+        // 홈 카드 리스트(limit 만큼만)
+        var items = userBooksRepository.listCurrentReading(
+                userId,
+                PageRequest.of(0, safeLimit)
+        );
+
+        return new CurrentReadingResponse(count, items);
     }
 }


### PR DESCRIPTION
- GET /api/v1/user-books/reading-books 추가
- READING 상태 기준 조회 + limit 지원
- 기존 UserBookListItemResponse 재사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint to retrieve a user's currently reading books with pagination support. The endpoint includes the total count of currently reading books and returns relevant book details for display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->