### PR TITLE
feat: add book detail booklog list api

### DIFF
--- a/booklog/src/main/java/com/example/booklog/domain/booklog/controller/BooklogByBookController.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/controller/BooklogByBookController.java
@@ -1,0 +1,41 @@
+package com.example.booklog.domain.booklog.controller;
+
+import com.example.booklog.domain.booklog.dto.BooklogFeedResponse;
+import com.example.booklog.domain.booklog.service.BooklogReadFacade;
+import com.example.booklog.global.auth.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Book", description = "도서 상세 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/books")
+public class BooklogByBookController {
+
+    private final BooklogReadFacade booklogReadFacade;
+
+    @Operation(summary = "특정 책의 북로그 목록 조회")
+    @GetMapping("/{bookId}/booklogs")
+    public ResponseEntity<BooklogFeedResponse> getBooklogsByBook(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long bookId,
+            @ParameterObject Pageable pageable
+    ) {
+        Long viewerId = userDetails.getUserId();
+
+        // 1) 해당 bookId 기준으로 Slice 조회
+        var slice = booklogReadFacade.findBookPostsSlice(bookId, pageable);
+
+        // 2) 기존 피드 카드 조립 로직 재사용
+        BooklogFeedResponse response =
+                booklogReadFacade.assembleFeedCards(viewerId, slice);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacade.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacade.java
@@ -30,4 +30,5 @@ public interface BooklogReadFacade {
     BooklogRecommendationResponse buildRecommendations(Long postId);
     void validateCreateRequest(Long userId, Long bookId);
     BooklogFeedResponse assembleFeedCards(Long viewerId, Slice<BooklogPost> slice);
+    Slice<BooklogPost> findBookPostsSlice(Long bookId, Pageable pageable);
 }

--- a/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacadeImpl.java
+++ b/booklog/src/main/java/com/example/booklog/domain/booklog/service/BooklogReadFacadeImpl.java
@@ -284,5 +284,14 @@ public class BooklogReadFacadeImpl implements BooklogReadFacade {
         return feedConverter.toFeedResponse(cards, slice.hasNext());
     }
 
+    @Override
+    public Slice<BooklogPost> findBookPostsSlice(Long bookId, Pageable pageable) {
+        return postRepository.findAllByBookIdAndStatusOrderByCreatedAtDesc(
+                bookId,
+                BooklogStatus.PUBLISHED,
+                pageable
+        );
+    }
+
 
 }


### PR DESCRIPTION
- 책 상세에서 해당 책의 북로그 목록 조회 API 추가
- GET /api/v1/books/{bookId}/booklogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new endpoint for retrieving all posts and activity logs associated with a specific book. The endpoint supports pagination to efficiently handle large volumes of content and provides personalized feed cards for authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->